### PR TITLE
Add an input filed to specify a WebSocket protocol.

### DIFF
--- a/src/main/index.html
+++ b/src/main/index.html
@@ -124,9 +124,13 @@
 					</h4>
 					<select id="urlSelect" class="custom-select"></select>
 					<input id="urlInput"
+						    class="form-control bwc-margin-top"
+						    type="text"
+						    placeholder="Enter the server URL here"/>
+					<input id="protoInput"
 						   class="form-control bwc-margin-top"
 						   type="text"
-						   placeholder="Enter the server URL here"/>
+						   placeholder="Enter the protocol name here (or leave empty)"/>
 					<p>
 						Status:
 						<span id="connectionStatus">

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -93,6 +93,7 @@ const optionsUrlSaveButton = $('#optionsUrlSaveButton')
 const optionsUrlSavedTable = $('#optionsUrlSavedTable')
 const optionsUrlStatus = $('#optionsUrlStatus')
 const urlInput = $('#urlInput')
+const protoInput = $('#protoInput')
 const urlSelect = $('#urlSelect')
 const url = document.location.toString()
 let editingUrl = false
@@ -523,7 +524,11 @@ clearMessagesButton.click(function () {
 // Open WebSocket connection
 APP.open = function () {
   let url = urlInput.val()
-  ws = new WebSocket(url)
+  let proto = protoInput.val()
+  if (proto)
+    ws = new WebSocket(url, proto)
+  else
+    ws = new WebSocket(url)
   ws.onopen = APP.onOpen
   ws.onclose = APP.onClose
   ws.onmessage = APP.onMessage
@@ -548,6 +553,7 @@ APP.onOpen = function () {
   disconnectButton.show()
   messageSendButton.prop('disabled', false)
   urlInput.prop('disabled', true)
+  protoInput.prop('disabled', true)
   wsPoliteDisconnection = false
 }
 
@@ -563,6 +569,7 @@ APP.onClose = function () {
   disconnectButton.hide()
   messageSendButton.prop('disabled', true)
   urlInput.prop('disabled', false)
+  protoInput.prop('disabled', false)
 }
 
 // WebSocket onMessage handler


### PR DESCRIPTION
According to WebSockets API specification it is possible to specify
a protocol (an arbitrary string, which does matter only for
particular (custom) server) to `WebSocket` ctor.

This patch adds an input field for the protocol...