### PR TITLE
Highlight partially valid JSON in message area

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@fortawesome/fontawesome": "1.1.8",
     "@fortawesome/fontawesome-free-regular": "5.0.13",
     "@fortawesome/fontawesome-free-solid": "5.0.13",
+    "acorn": "^6.0.7",
     "bootstrap": "4.1.3",
     "jquery": "3.3.1",
     "popper.js": "1.14.4"

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1123,5 +1123,6 @@ export {
   getProtocols,
   isValidJson,
   isValidUrl,
-  highlightJson
+  highlightJson,
+  parseData
 }

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -976,8 +976,8 @@ const onClose = function () {
 
 // WebSocket onMessage handler
 const onMessage = function (event) {
-  if (event.data != 3) {
-     addMessage(event.data)
+  if (event.data !== 3) {
+    addMessage(event.data)
   }
 }
 
@@ -986,7 +986,7 @@ const onError = function (event) {
   console.error(event.data)
 }
 
-const parseData = function(data) {
+const parseData = function (data) {
   let indexOfMin = Math.min(data.indexOf("{"), data.indexOf("["))
   let indexOfMax = Math.max(data.indexOf("{"), data.indexOf("["))
   let indexOf = indexOfMin > -1 ? indexOfMin : indexOfMax
@@ -1006,7 +1006,7 @@ const addMessage = function (data, type) {
     if (isValidJson(mightBeJson) && pingInterval == null) {
       const initialJson = JSON.parse(mightBeJson)
       if (initialJson.pingInterval > 0) {
-        pingInterval = setInterval(function() {
+        pingInterval = setInterval(function () {
           ws.send(2)
         }, initialJson.pingInterval)
       }
@@ -1016,7 +1016,7 @@ const addMessage = function (data, type) {
       .attr('class', 'bwc-pointer bwc-received')
       .text(data)
       .on('click', function () {
-        let body;
+        let body
         if (isValidJson(mightBeJson)) {
           const json = JSON.parse(mightBeJson)
           body = $('<pre>').html(highlightJson(JSON.stringify(json, null, 2)))

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -940,7 +940,6 @@ const close = function () {
   }
 }
 
-let pingInterval
 // WebSocket onOpen handler
 const onOpen = function () {
   console.log('OPENED: ' + urlInput.val())
@@ -961,7 +960,6 @@ const onClose = function () {
   let disconnectionMessage = 'CLOSED'
   disconnectionMessage += (wsPoliteDisconnection) ? '' : '. Disconnected by the server.'
   console.log('CLOSED: ' + urlInput.val())
-  clearInterval(pingInterval)
   ws = null
   connectButton
     .prop('disabled', false)
@@ -976,9 +974,7 @@ const onClose = function () {
 
 // WebSocket onMessage handler
 const onMessage = function (event) {
-  if (event.data !== 3) {
-    addMessage(event.data)
-  }
+  addMessage(event.data)
 }
 
 // WebSocket onError handler
@@ -1003,14 +999,6 @@ const addMessage = function (data, type) {
       .text(data)
   } else {
     let mightBeJson = parseData(data)
-    if (isValidJson(mightBeJson) && pingInterval == null) {
-      const initialJson = JSON.parse(mightBeJson)
-      if (initialJson.pingInterval > 0) {
-        pingInterval = setInterval(function () {
-          ws.send(2)
-        }, initialJson.pingInterval)
-      }
-    }
 
     message = $('<pre>')
       .attr('class', 'bwc-pointer bwc-received')

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1015,10 +1015,8 @@ const addMessage = function (data, type) {
     message = $('<pre>')
       .attr('class', 'bwc-pointer bwc-received')
       .text(data)
-      .data('target', data)
       .on('click', function () {
         let body;
-        let target = jQuery(this).data('target');
         if (isValidJson(mightBeJson)) {
           const json = JSON.parse(mightBeJson)
           body = $('<pre>').html(highlightJson(JSON.stringify(json, null, 2)))

--- a/src/test/cypress/integration/cy.unit.spec.js
+++ b/src/test/cypress/integration/cy.unit.spec.js
@@ -2,9 +2,20 @@ import { convertJsonToString, deleteOptions, getProtocols, highlightJson, isVali
 
 describe('Unit Tests', function () {
   const jsonMessageValid = '{"Message 1":{"null":null,"number":42,"string":"is the answer to everything","boolean":false}}'
+  const containsValidJson1 = '42[1, {"valid":"json"}]'
+  const containsValidJson2 = '42{"valid":"json"}'
 
   before(() => {
     cy.mockChromeStorageAndVisit()
+  })
+
+  describe('parseData()', function () {
+    it('should return JSON', function() {
+      let json1 = parseData(containsValidJson1)
+      let json2 = parseData(containsValidJson2)
+      expect(json1).to.eq('[1, {"valid":"json"}]')
+      expect(json2).to.eq('{"valid":"json"}')
+    })
   })
 
   describe('highlightJson()', function () {
@@ -38,6 +49,11 @@ describe('Unit Tests', function () {
     const object = {'question': 'answer'}
     const string = '{"question": "answer"}'
     const result = '{"question":"answer"}'
+
+    it('should not fail on invalid json', function () {
+      let invalidJson = "40,[1,2,3]"
+      expect(convertJsonToString(invalidJson)).to.eq(invalidJson)
+    })
 
     it('should return a string if passed an object', function () {
       expect(convertJsonToString(object)).to.eq(result)
@@ -110,7 +126,7 @@ describe('Unit Tests', function () {
       expect(getProtocols(input)).to.eq(null)
     })
   })
-  
+
   describe('deleteOptions()', function () {
     const SEPARATOR = '\u0007'
     let savedOptions
@@ -150,7 +166,7 @@ describe('Unit Tests', function () {
       expect(options.protocols.length).to.eq(1, 'protocols')
       expect(options.urls.length).to.eq(3, 'urls')
     })
-    
+
     it('switch.url', function () {
       const options = deleteOptions('url', 'ws://localhost:8080/ws/one', savedOptions)
       expect(options.messages.length).to.eq(3, 'messages')

--- a/src/test/cypress/integration/cy.unit.spec.js
+++ b/src/test/cypress/integration/cy.unit.spec.js
@@ -1,4 +1,4 @@
-import { convertJsonToString, deleteOptions, getProtocols, highlightJson, isValidJson, isValidUrl } from '../../../main/index'
+import { convertJsonToString, deleteOptions, getProtocols, highlightJson, isValidJson, isValidUrl, parseData } from '../../../main/index'
 
 describe('Unit Tests', function () {
   const jsonMessageValid = '{"Message 1":{"null":null,"number":42,"string":"is the answer to everything","boolean":false}}'
@@ -10,11 +10,11 @@ describe('Unit Tests', function () {
   })
 
   describe('parseData()', function () {
-    it('should return JSON', function() {
-      let json1 = parseData(containsValidJson1)
-      let json2 = parseData(containsValidJson2)
-      expect(json1).to.eq('[1, {"valid":"json"}]')
-      expect(json2).to.eq('{"valid":"json"}')
+    it('should return string with valid JSON', function() {
+      let data1 = parseData(containsValidJson1)
+      let data2 = parseData(containsValidJson2)
+      expect(data1).to.eq('[1, {"valid":"json"}]')
+      expect(data2).to.eq('{"valid":"json"}')
     })
   })
 


### PR DESCRIPTION
- There's ability to send not valid JSON via WS I'd like to be able "save" such messages
- Server might respond with partially valid JSON (e. g. `42{"valid":"json"}` or `42["some", {"valid":"json"}]`) I'd like to have ability to preview such responses
- Make sure `convertJsonToString` works for strings without JSON